### PR TITLE
Improve readability of tests

### DIFF
--- a/tests/FormMakerTest.php
+++ b/tests/FormMakerTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Illuminate\Support\Facades\Config;
 use Illuminate\Container\Container as Container;
 use Illuminate\Support\Facades\Facade as Facade;
 use Yab\FormMaker\Services\FormMaker;
@@ -61,7 +60,7 @@ class FormMakerTest extends PHPUnit_Framework_TestCase
         $test = $this->formMaker->fromArray($testArray);
 
         $this->assertTrue(is_string($test));
-        $this->assertEquals($test, '<div class="form-group "><label class="control-label" for="Name">Name</label><input  id="Name" class="form-control" type="text" name="name"    placeholder="Name"></div><div class="form-group "><label class="control-label" for="Age">Number</label><input  id="Age" class="form-control" type="number" name="age"    placeholder="Number"></div>');
+        $this->assertEquals('<div class="form-group "><label class="control-label" for="Name">Name</label><input  id="Name" class="form-control" type="text" name="name"    placeholder="Name"></div><div class="form-group "><label class="control-label" for="Age">Number</label><input  id="Age" class="form-control" type="number" name="age"    placeholder="Number"></div>', $test);
     }
 
     public function testFromArrayWithColumns()
@@ -74,18 +73,17 @@ class FormMakerTest extends PHPUnit_Framework_TestCase
         $test = $this->formMaker->fromArray($testArray, ['name']);
 
         $this->assertTrue(is_string($test));
-        $this->assertEquals($test, '<div class="form-group "><label class="control-label" for="Name">Name</label><input  id="Name" class="form-control" type="text" name="name"    placeholder="Name"></div>');
+        $this->assertEquals('<div class="form-group "><label class="control-label" for="Name">Name</label><input  id="Name" class="form-control" type="text" name="name"    placeholder="Name"></div>', $test);
     }
 
     public function testFromObject()
     {
-        (object) $testObject = [
+        $testObject = [
             'attributes' => [
                 'name' => 'Joe',
                 'age' => 18,
             ],
         ];
-
         $columns = [
             'name' => [
                 'type' => 'string',
@@ -95,9 +93,9 @@ class FormMakerTest extends PHPUnit_Framework_TestCase
             ]
         ];
 
-        $test = $this->formMaker->fromObject($testObject, $columns);
+        $test = $this->formMaker->fromObject((object) $testObject, $columns);
 
         $this->assertTrue(is_string($test));
-        $this->assertEquals($test, '<div class="form-group "><label class="control-label" for="Name">Name</label><input  id="Name" class="form-control" type="text" name="name"    placeholder="Name"></div><div class="form-group "><label class="control-label" for="Age">Age</label><input  id="Age" class="form-control" type="number" name="age"    placeholder="Age"></div>');
+        $this->assertEquals('<div class="form-group "><label class="control-label" for="Name">Name</label><input  id="Name" class="form-control" type="text" name="name"    placeholder="Name"></div><div class="form-group "><label class="control-label" for="Age">Age</label><input  id="Age" class="form-control" type="number" name="age"    placeholder="Age"></div>', $test);
     }
 }

--- a/tests/HtmlGeneratorTest.php
+++ b/tests/HtmlGeneratorTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Illuminate\Support\Facades\Config;
 use Illuminate\Container\Container as Container;
 use Illuminate\Support\Facades\Facade as Facade;
 use Yab\FormMaker\Generators\HtmlGenerator;
@@ -32,7 +31,7 @@ class HtmlGeneratorTest extends PHPUnit_Framework_TestCase
         $test = $this->html->makeHidden(['name' => 'test'], 'test', '');
 
         $this->assertTrue(is_string($test));
-        $this->assertEquals($test, '<input  id="Test" name="test" type="hidden" value="test">');
+        $this->assertEquals('<input  id="Test" name="test" type="hidden" value="test">', $test);
     }
 
     public function testMakeText()
@@ -44,7 +43,7 @@ class HtmlGeneratorTest extends PHPUnit_Framework_TestCase
         ], 'simple-test', 'data-thing');
 
         $this->assertTrue(is_string($test));
-        $this->assertEquals($test, '<textarea data-thing id="Test" class="form-control" name="test" placeholder="TestText">simple-test</textarea>');
+        $this->assertEquals('<textarea data-thing id="Test" class="form-control" name="test" placeholder="TestText">simple-test</textarea>', $test);
     }
 
     public function testMakeSelected()
@@ -61,7 +60,7 @@ class HtmlGeneratorTest extends PHPUnit_Framework_TestCase
         ], 'member', 'data-thing');
 
         $this->assertTrue(is_string($test));
-        $this->assertEquals($test, '<select data-thing id="Test" class="form-control" name="test"><option value="admin" >Admin</option><option value="member" selected>Member</option></select>');
+        $this->assertEquals('<select data-thing id="Test" class="form-control" name="test"><option value="admin" >Admin</option><option value="member" selected>Member</option></select>', $test);
     }
 
     public function testMakeCheckbox()
@@ -72,7 +71,7 @@ class HtmlGeneratorTest extends PHPUnit_Framework_TestCase
         ], 'selected', '');
 
         $this->assertTrue(is_string($test));
-        $this->assertEquals($test, '<input  id="Test" selected type="checkbox" name="test">');
+        $this->assertEquals('<input  id="Test" selected type="checkbox" name="test">', $test);
     }
 
     public function testMakeRadio()
@@ -83,7 +82,7 @@ class HtmlGeneratorTest extends PHPUnit_Framework_TestCase
         ], 'selected', '');
 
         $this->assertTrue(is_string($test));
-        $this->assertEquals($test, '<input  id="Test" selected type="radio" name="test">');
+        $this->assertEquals('<input  id="Test" selected type="radio" name="test">', $test);
     }
 
     public function testMakeInputString()
@@ -102,6 +101,6 @@ class HtmlGeneratorTest extends PHPUnit_Framework_TestCase
         ]);
 
         $this->assertTrue(is_string($test));
-        $this->assertEquals($test, '<input data-stuff id="Test" class="form-control" type="text" name="test"   value="sample Test" placeholder="wtf">');
+        $this->assertEquals('<input data-stuff id="Test" class="form-control" type="text" name="test"   value="sample Test" placeholder="wtf">', $test);
     }
 }

--- a/tests/InputMakerTest.php
+++ b/tests/InputMakerTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Illuminate\Support\Facades\Config;
 use Illuminate\Container\Container as Container;
 use Illuminate\Support\Facades\Facade as Facade;
 use Yab\FormMaker\Services\InputMaker;


### PR DESCRIPTION
Made the tests somewhat better readable by for instance using assertContains instead of assertTrue(strpos(...) !== false). Also, changed the order of parameters in some cases, so the expected output is the first parameters. Both help in showing more accurate reasons why a test fails.

Also changed the test methods to a sort of 'given when then' format, to improve readability. And restructured the DatabaseGeneratorTest.