### PR TITLE
Add ability to change connection for formmaker 

### DIFF
--- a/src/Services/FormMaker.php
+++ b/src/Services/FormMaker.php
@@ -63,14 +63,15 @@ class FormMaker
         $view = null,
         $reformatted = true,
         $populated = false,
-        $idAndTimestamps = false
+        $idAndTimestamps = false,
+        $connetion = env('DB_CONNECTION', null)
     ) {
         $formBuild = '';
-        $tableColumns = Schema::getColumnListing($table);
+        $tableColumns = Schema::connection($connection)->getColumnListing($table);
 
         if (is_null($columns)) {
             foreach ($tableColumns as $column) {
-                $type = DB::connection()->getDoctrineColumn($table, $column)->getType()->getName();
+                $type = DB::connection($connection)->getDoctrineColumn($table, $column)->getType()->getName();
                 $columns[$column] = $type;
             }
         }
@@ -338,9 +339,9 @@ class FormMaker
      *
      * @return array
      */
-    public function getTableColumns($table, $allColumns = false)
+    public function getTableColumns($table, $allColumns = false, $connection = null)
     {
-        $tableColumns = Schema::getColumnListing($table);
+        $tableColumns = Schema::connection($connection)->getColumnListing($table);
 
         $tableTypeColumns = [];
         $badColumns = ['id', 'created_at', 'updated_at'];
@@ -351,7 +352,7 @@ class FormMaker
 
         foreach ($tableColumns as $column) {
             if (!in_array($column, $badColumns)) {
-                $type = DB::connection()->getDoctrineColumn($table, $column)->getType()->getName();
+                $type = DB::connection($connection)->getDoctrineColumn($table, $column)->getType()->getName();
                 $tableTypeColumns[$column]['type'] = $type;
             }
         }

--- a/src/Services/FormMaker.php
+++ b/src/Services/FormMaker.php
@@ -64,7 +64,7 @@ class FormMaker
         $reformatted = true,
         $populated = false,
         $idAndTimestamps = false,
-        $connetion = env('DB_CONNECTION', null)
+        $connetion = null
     ) {
         $formBuild = '';
         $tableColumns = Schema::connection($connection)->getColumnListing($table);

--- a/src/Services/InputMaker.php
+++ b/src/Services/InputMaker.php
@@ -300,7 +300,7 @@ class InputMaker
             $nameProperties = explode('[', $config['objectValue']);
             foreach ($nameProperties as $property) {
                 $realProperty = str_replace(']', '', $property);
-                $final = $final->$realProperty;
+                $final = $final[$realProperty];
             }
             $config['objectValue'] = $final;
         }


### PR DESCRIPTION
This resolves #7 when using getTableColumns and fromTable and also resolves a glitch in InputMaker 
```
                $final = $final->$realProperty;
```
Could return `PHP error:  Trying to get property of non-object` because config['object'] could return an array making the line similar to something like
```
array('a'=>'0','b'=>'1','c'=>'2')->a
```
which will return the same error. 