### PR TITLE
Bugfix/checkbox custom class config

### DIFF
--- a/src/Generators/HtmlGenerator.php
+++ b/src/Generators/HtmlGenerator.php
@@ -80,7 +80,7 @@ class HtmlGenerator
      */
     public function makeCheckbox($config, $selected, $custom)
     {
-        return '<input '.$custom.' id="'.ucfirst($config['name']).'" '.$selected.' type="checkbox" name="'.$config['name'].'">';
+        return '<input '.$custom.' id="'.ucfirst($config['name']).'" '.$selected.' type="checkbox" name="'.$config['name'].'" class='. $config['config']['class'] .'>';
     }
 
     /**
@@ -94,7 +94,7 @@ class HtmlGenerator
      */
     public function makeRadio($config, $selected, $custom)
     {
-        return '<input '.$custom.' id="'.ucfirst($config['name']).'" '.$selected.' type="radio" name="'.$config['name'].'">';
+        return '<input '.$custom.' id="'.ucfirst($config['name']).'" '.$selected.' type="radio" name="'.$config['name'].'" class='. $config['config']['class'] .'>';
     }
 
     /*

--- a/src/Services/FormMaker.php
+++ b/src/Services/FormMaker.php
@@ -284,6 +284,7 @@ class FormMaker
                 'labelFor' => ucfirst($column),
                 'label' => $this->columnLabel($field, $column),
                 'input' => $input,
+                'field' => $field,
                 'errorMessage' => $this->errorMessage($errorMessage),
                 'errorHighlight' => $errorHighlight,
             ]);

--- a/tests/HtmlGeneratorTest.php
+++ b/tests/HtmlGeneratorTest.php
@@ -67,22 +67,22 @@ class HtmlGeneratorTest extends TestCase
     {
         $test = $this->html->makeCheckbox([
             'name' => 'test',
-            'class' => 'form-control',
+            'class' => 'customClass',
         ], 'selected', '');
 
         $this->assertTrue(is_string($test));
-        $this->assertEquals('<input  id="Test" selected type="checkbox" name="test">', $test);
+        $this->assertEquals('<input  id="Test" selected type="checkbox" name="test" class="customClass">', $test);
     }
 
     public function testMakeRadio()
     {
         $test = $this->html->makeRadio([
             'name' => 'test',
-            'class' => 'form-control',
+            'class' => 'customClass',
         ], 'selected', '');
 
         $this->assertTrue(is_string($test));
-        $this->assertEquals('<input  id="Test" selected type="radio" name="test">', $test);
+        $this->assertEquals('<input  id="Test" selected type="radio" name="test" class="customClass">', $test);
     }
 
     public function testMakeInputString()


### PR DESCRIPTION
If i want to pass a __custom class__ to __checkbox__ and __radio__ i can't because the default `form-control` not needed here and the `HtmlGenerator.php` not include the `class="'.$config['class'].'" ` ot in this case the `class="'.$config['config']['class'].'" ` for get only the custom one and not the default merget with `form-control` or what else.... 

I think it right to allow for passing custom class, in my example for iCheck jquery plugin that require it
