### PR TITLE
Change property access to method call when getting selected value for multi-selects

### DIFF
--- a/src/Generators/HtmlGenerator.php
+++ b/src/Generators/HtmlGenerator.php
@@ -178,7 +178,7 @@ class HtmlGenerator
                     $selected = $object->$relationship()->first()->$value;
                 }
             } else {
-                $selected = $class->$method->pluck($value, $label);
+                $selected = $class->$method()->pluck($value, $label);
             }
         } else {
             $selected = $config['config']['selected'];


### PR DESCRIPTION
Fixes 'Undefined property: xxx::$all'

... which occurs when populating related data using a repository or service where dynamic properties are not available.